### PR TITLE
feat: implement tracing

### DIFF
--- a/ascent/Cargo.toml
+++ b/ascent/Cargo.toml
@@ -27,7 +27,7 @@ boxcar = "0.1.0"
 once_cell = "1.13.1"
 paste = "1.0"
 
-[dev_dependencies]
+[dev-dependencies]
 
 [features]
 wasm-bindgen = ["instant/wasm-bindgen"]

--- a/ascent_macro/Cargo.toml
+++ b/ascent_macro/Cargo.toml
@@ -24,6 +24,5 @@ lazy_static = "1.4.0"
 duplicate = { version = "1.0.0", default-features = false }
 
 [dev-dependencies]
-ascent = { path = "../ascent" }
 rayon = "1.5"
 crossbeam = "0.8"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 profile = "default"
-channel = "1.66"
+channel = "stable"


### PR DESCRIPTION
This PR introduces two new tracing attributes to enhance debugging capabilities in Ascent programs:

1. `#[trace(...)]`: A rule-level attribute for custom tracing.
2. `#![trace]`: A top-level attribute for automatic tracing of all rules.

### Rule-level Tracing

Users can add custom trace statements to individual rules:

```rust
#[trace(format = "hello {}, {}, {}", x, y, z)]
fib(x, y + z) <-- number(x), if *x >= 2, fib(x - 1, y), fib(x - 2, z);
```

This will generate a `println!` statement with the specified format and arguments.

### Automatic Tracing

By adding `#![trace]` at the top of an Ascent program, all rules will automatically generate trace statements:

```rust
#![trace]

ascent! {
    relation number(isize);
    relation fib(isize, isize);

    fib(0, 1) <-- number(0);
    fib(1, 1) <-- number(1);
    fib(x, y + z) <-- number(x), if *x >= 2, fib(x - 1, y), fib(x - 2, z);
}
```

For the last rule, this will generate a trace statement equivalent to:

```rust
println!("fib({}, {}) <-- number({}), if ..., fib({}, {}), fib({}, {})", x, y + z, x, x - 1, y, x - 2, z);
```

## Implementation Details

- Added `TraceAttribute` struct to parse and store trace information.
- Modified `RuleNode`, `IrRule`, and `MirRule` to include trace attributes.
- Implemented automatic trace generation for rules when `#![trace]` is present.
- Updated code generation to include trace statements in the compiled output.

## Notes

- Rule-level `#[trace(...)]` attributes take precedence over the top-level `#![trace]` attribute.
- For `if`, `if let`, `agg`, and `for` clauses in rule bodies, the trace output shows only the clause type (e.g., "if ...") to keep the output concise.
```