### PR TITLE
feat: Add support for user-defined struct fields

### DIFF
--- a/ascent/examples/fibonacci.rs
+++ b/ascent/examples/fibonacci.rs
@@ -4,23 +4,15 @@ use ascent::ascent;
 
 ascent! {
     // Facts:
-
     relation number(isize);
 
     // Rules:
-
     relation fib(isize, isize);
     relation fib_table(isize, isize, isize, isize, isize);
 
     fib(0, 1) <-- number(0);
     fib(1, 1) <-- number(1);
-    fib_table(x, x - 1, y, x - 2, z), fib(x, y + z) <-- number(x), if *x >= 2, fib(x - 1, y), fib(x - 2, z);
-    // basically collect the queries on the RHS into a tuple, so
-    // - number(x) -> x
-    // - fib(x - 1, y) -> x - 1, y
-    // - fib(x - 2, z) -> x - 2, z
-    // and in total we get x, x-1, y, x-2, z
-    // fib_table(x, x - 1, y, x - 2, z) <-- number(x), if *x >= 2, fib(x - 1, y), fib(x - 2, z);
+    fib(x, y + z) <-- number(x), if *x >= 2, fib(x - 1, y), fib(x - 2, z);
 }
 
 fn main() {
@@ -30,11 +22,9 @@ fn main() {
 
     prog.run();
 
-    let AscentProgram { mut fib, mut fib_table, .. } = prog;
+    let AscentProgram { mut fib, .. } = prog;
 
     fib.sort_by_key(|(key, _)| *key);
-    fib_table.sort_by_key(|(key, _, _, _, _)| *key);
 
     assert_eq!(fib, vec![(0, 1), (1, 1), (2, 2), (3, 3), (4, 5), (5, 8),]);
-    println!("{:?}", fib_table);
 }

--- a/ascent_macro/src/ascent_codegen.rs
+++ b/ascent_macro/src/ascent_codegen.rs
@@ -69,6 +69,12 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
         }
     }
 
+    let user_fields = &mir.signatures.declaration.fields;
+    let user_field_defaults = user_fields.iter().map(|f| {
+        let name = &f.ident;
+        quote! { #name: Default::default(), }
+    });
+
     let sccs_ordered = &mir.sccs;
     let mut rule_time_fields = vec![];
     let mut rule_time_fields_defaults = vec![];
@@ -309,6 +315,7 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
        #(#struct_attrs)*
        #vis struct #struct_name #ty_impl_generics #ty_where_clause {
           #(#relation_fields)*
+          #user_fields
           scc_times: [std::time::Duration; #sccs_count],
           scc_iters: [usize; #sccs_count],
           #(#rule_time_fields)*
@@ -347,6 +354,7 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
           fn default() -> Self {
              let mut _self = #struct_name {
                 #(#field_defaults)*
+                #(#user_field_defaults)*
                 scc_times: [std::time::Duration::ZERO; #sccs_count],
                 scc_iters: [0; #sccs_count],
                 #(#rule_time_fields_defaults)*


### PR DESCRIPTION
This PR extends the Ascent syntax to allow users to define custom fields in the struct declaration at the beginning of an Ascent program. 

## Example Usage

```rust
ascent! {
    struct FibProgram {
        my_field: usize,
    };

    // Facts and rules follow...
}
```